### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log


### PR DESCRIPTION
@tmcw is there any reason not to include a `.gitignore` here for `npm-debug.log` and `node_modules`?
